### PR TITLE
added simulate (-n) and stop_after_first_match (-1) options

### DIFF
--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -39,7 +39,7 @@ usage(const char *name)
 {
 	fprintf(stderr,
 "oclVanitygen %s (" OPENSSL_VERSION_TEXT ")\n"
-"Usage: %s [-vqrikNTS] [-d <device>] [-f <filename>|-] [<pattern>...]\n"
+"Usage: %s [-vqrik1NTS] [-d <device>] [-f <filename>|-] [<pattern>...]\n"
 "Generates a bitcoin receiving address matching <pattern>, and outputs the\n"
 "address and associated private key.  The private key may be stored in a safe\n"
 "location or imported into a bitcoin client to spend any balance received on\n"
@@ -56,6 +56,7 @@ usage(const char *name)
 "-q            Quiet output\n"
 "-i            Case-insensitive prefix search\n"
 "-k            Keep pattern and continue search after finding a match\n"
+"-1            Stop after first match\n"
 "-N            Generate namecoin address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
@@ -102,6 +103,7 @@ main(int argc, char **argv)
 	int nrows = 0, ncols = 0;
 	int invsize = 0;
 	int remove_on_match = 1;
+	int only_one = 0;
 	int verify_mode = 0;
 	int safe_mode = 0;
 	vg_context_t *vcp = NULL;
@@ -121,7 +123,7 @@ main(int argc, char **argv)
 	int i;
 
 	while ((opt = getopt(argc, argv,
-			     "vqikNTX:eE:p:P:d:w:t:g:b:VSh?f:o:s:D:")) != -1) {
+			     "vqik1NTX:eE:p:P:d:w:t:g:b:VSh?f:o:s:D:")) != -1) {
 		switch (opt) {
 		case 'v':
 			verbose = 2;
@@ -134,6 +136,9 @@ main(int argc, char **argv)
 			break;
 		case 'k':
 			remove_on_match = 0;
+			break;
+		case '1':
+			only_one = 1;
 			break;
 		case 'N':
 			addrtype = 52;
@@ -328,6 +333,7 @@ main(int argc, char **argv)
 	vcp->vc_verbose = verbose;
 	vcp->vc_result_file = result_file;
 	vcp->vc_remove_on_match = remove_on_match;
+	vcp->vc_only_one = only_one;
 	vcp->vc_pubkeytype = addrtype;
 	vcp->vc_pubkey_base = pubkey_base;
 

--- a/pattern.c
+++ b/pattern.c
@@ -1489,6 +1489,10 @@ research:
 
 		vcpp->base.vc_found++;
 
+		if (vcpp->base.vc_only_one) {
+			return 2;
+		}
+
 		if (vcpp->base.vc_remove_on_match) {
 			/* Subtract the range from the difficulty */
 			vg_prefix_range_sum(vp,
@@ -1783,6 +1787,11 @@ restart_loop:
 		vcrp->base.vc_output_match(&vcrp->base, vxcp->vxc_key,
 					   vcrp->vcr_regex_pat[i]);
 		vcrp->base.vc_found++;
+
+		if (vcrp->base.vc_only_one) {
+			res = 2;
+			goto out;
+		}
 
 		if (vcrp->base.vc_remove_on_match) {
 			pcre_free(vcrp->vcr_regex[i]);

--- a/pattern.h
+++ b/pattern.h
@@ -98,6 +98,7 @@ struct _vg_context_s {
 	const char		*vc_result_file;
 	const char		*vc_key_protect_pass;
 	int			vc_remove_on_match;
+	int			vc_only_one;
 	int			vc_verbose;
 	enum vg_format		vc_format;
 	int			vc_pubkeytype;


### PR DESCRIPTION
The options are pretty much self-explanatory.

I added `-1` to both regular and ocl versions, while `-n` only to the regular one. Not sure if this is good, let me know.
