### PR TITLE
Display meaningful "value" in oclvanityminer

### DIFF
--- a/oclvanityminer.c
+++ b/oclvanityminer.c
@@ -319,7 +319,7 @@ server_workitem_new(server_request_t *reqp,
 	wip->addrtype = addrtype;
 	wip->difficulty = difficulty;
 	wip->reward = reward;
-	wip->value = (reward * 1000000.0) / difficulty;
+	wip->value = (reward * 1000000000.0) / difficulty;
 
 	return wip;
 }
@@ -554,13 +554,13 @@ dump_work(avl_root_t *work)
 		     wip != NULL;
 		     wip = workitem_avl_next(wip)) {
 			printf("Pattern: \"%s\" Reward: %f "
-			       "Value: %f BTC/Mkey\n",
+			       "Value: %f BTC/Gkey\n",
 			       wip->pattern,
 			       wip->reward,
 			       wip->value);
 		}
 		if (pbatch->nitems > 1)
-			printf("Batch of %d, total value: %f BTC/Mkey\n",
+			printf("Batch of %d, total value: %f BTC/Gkey\n",
 			       pbatch->nitems, pbatch->total_value);
 	}
 }
@@ -1024,7 +1024,7 @@ main(int argc, char **argv)
 			     wip = workitem_avl_next(wip)) {
 				fprintf(stderr,
 					"Searching for pattern: \"%s\" "
-					"Reward: %f Value: %f BTC/Mkey\n",
+					"Reward: %f Value: %f BTC/Gkey\n",
 					wip->pattern,
 					wip->reward,
 					wip->value);
@@ -1043,7 +1043,7 @@ main(int argc, char **argv)
 			}
 
 			fprintf(stderr, 
-				"\nTotal value for current work: %f BTC/Mkey\n", 
+				"\nTotal value for current work: %f BTC/Gkey\n", 
 				active_pkb_value);
 			res = vg_context_start_threads(vcp);
 			if (res)

--- a/oclvanityminer.c
+++ b/oclvanityminer.c
@@ -319,7 +319,7 @@ server_workitem_new(server_request_t *reqp,
 	wip->addrtype = addrtype;
 	wip->difficulty = difficulty;
 	wip->reward = reward;
-	wip->value = (reward * 1000000.0 * 3600.0) / difficulty;
+	wip->value = (reward * 1000000.0) / difficulty;
 
 	return wip;
 }
@@ -554,13 +554,13 @@ dump_work(avl_root_t *work)
 		     wip != NULL;
 		     wip = workitem_avl_next(wip)) {
 			printf("Pattern: \"%s\" Reward: %f "
-			       "Value: %f BTC/MkeyHr\n",
+			       "Value: %f BTC/Mkey\n",
 			       wip->pattern,
 			       wip->reward,
 			       wip->value);
 		}
 		if (pbatch->nitems > 1)
-			printf("Batch of %d, total value: %f BTC/MkeyHr\n",
+			printf("Batch of %d, total value: %f BTC/Mkey\n",
 			       pbatch->nitems, pbatch->total_value);
 	}
 }
@@ -1022,7 +1022,7 @@ main(int argc, char **argv)
 			     wip = workitem_avl_next(wip)) {
 				fprintf(stderr,
 					"Searching for pattern: \"%s\" "
-					"Reward: %f Value: %f BTC/MkeyHr\n",
+					"Reward: %f Value: %f BTC/Mkey\n",
 					wip->pattern,
 					wip->reward,
 					wip->value);

--- a/oclvanityminer.c
+++ b/oclvanityminer.c
@@ -802,6 +802,7 @@ main(int argc, char **argv)
 	int res;
 	int thread_started = 0;
 	pubkeybatch_t *active_pkb = NULL;
+	float active_pkb_value = 0;
 
 	server_context_t *scp = NULL;
 	pubkeybatch_t *pkb;
@@ -1016,6 +1017,7 @@ main(int argc, char **argv)
 		} else if (!active_pkb) {
 			workitem_t *wip;
 			was_sleeping = 0;
+			active_pkb_value = 0;
 			vcp->vc_pubkey_base = pkb->pubkey;
 			for (wip = workitem_avl_first(&pkb->items);
 			     wip != NULL;
@@ -1033,9 +1035,16 @@ main(int argc, char **argv)
 					fprintf(stderr,
 					   "WARNING: could not add pattern\n");
 				}
+				else {
+					active_pkb_value += wip->value;
+				}
+				
 				assert(vcp->vc_npatterns);
 			}
 
+			fprintf(stderr, 
+				"\nTotal value for current work: %f BTC/Mkey\n", 
+				active_pkb_value);
 			res = vg_context_start_threads(vcp);
 			if (res)
 				return 1;


### PR DESCRIPTION
Units of BTC/MkeyHr are meaningless. Change them to BTC/Gkey (expected
earnings per billion keys generated).
Also display a "total value" before starting a new pubkeybatch. This tells the user 
how much they are expected to earn.
