### PR TITLE
add homebrew patch

### DIFF
--- a/contrib/homebrew.patch
+++ b/contrib/homebrew.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 3486201..aebc128 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,7 @@
+-LIBS=-lpcre -lcrypto -lm -lpthread
+-CFLAGS=-ggdb -O3 -Wall
++LIBS= -lpcre -lcrypto -lm -lpthread
++INCPATHS=-I$(shell brew --prefix)/include -I$(shell brew --prefix openssl)/include
++LIBPATHS=-L$(shell brew --prefix)/lib -L$(shell brew --prefix openssl)/lib
++CFLAGS=-ggdb -O3 -Wall -Qunused-arguments $(INCPATHS) $(LIBPATHS)
+ OBJS=vanitygen.o oclvanitygen.o oclvanityminer.o oclengine.o keyconv.o pattern.o util.o
+ PROGS=vanitygen keyconv oclvanitygen oclvanityminer
+ 


### PR DESCRIPTION
This patch is necessary to build in a Homebrew environment using Homebrew's openssl and pcre packages. Ideally, use a proper formula.

See also WyseNynja/homebrew-bitcoin#2. Installing with Homebrew via that formula requires no modification, as Homebrew correctly provides the openssl and pcre paths.
