### PR TITLE
Compressed address support

### DIFF
--- a/bulkwallet.sh
+++ b/bulkwallet.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# a simple bulk-wallet generator
+#
+# 3 arguments needed: address version, pattern, count
+#
+# some address versions:
+# 0   Bitcoin
+# 23  Primecoin
+# 48  Litecoin
+
+./vanitygen -kF compressed -X $1 $2 2>/dev/null | egrep "Address|Privkey" | awk '{printf("%s ", $2); getline; printf("%s\n",$2)}' | head -n $3

--- a/bulkwallet.sh
+++ b/bulkwallet.sh
@@ -9,4 +9,4 @@
 # 23  Primecoin
 # 48  Litecoin
 
-./vanitygen -kF compressed -X $1 $2 2>/dev/null | egrep "Address|Privkey" | awk '{printf("%s ", $2); getline; printf("%s\n",$2)}' | head -n $3
+./vanitygen -kF compressed -X $1 $2 2>/dev/null | head -n `expr $3 \* 3` | egrep "Address|Privkey" | awk '{printf("%s ", $2); getline; printf("%s\n",$2)}'

--- a/oclengine.c
+++ b/oclengine.c
@@ -933,6 +933,9 @@ vg_ocl_init(vg_context_t *vcp, vg_ocl_context_t *vocp, cl_device_id did,
 	if (vocp->voc_quirks & VG_OCL_AMD_BFI_INT)
 		end += snprintf(optbuf + end, sizeof(optbuf) - end,
 				"-DAMD_BFI_INT ");
+	if (vcp->vc_compressed)
+		end += snprintf(optbuf + end, sizeof(optbuf) - end,
+				"-DCOMPRESSED_ADDRESS");
 	if (vocp->voc_quirks & VG_OCL_NV_VERBOSE)
 		end += snprintf(optbuf + end, sizeof(optbuf) - end,
 				"-cl-nv-verbose ");

--- a/oclengine.c
+++ b/oclengine.c
@@ -456,7 +456,7 @@ vg_ocl_get_quirks(vg_ocl_context_t *vocp)
 	default:
 		break;
 	}
-	return quirks;
+	return (quirks & ~VG_OCL_AMD_BFI_INT);
 }
 
 static int

--- a/oclengine.c
+++ b/oclengine.c
@@ -677,8 +677,9 @@ vg_ocl_load_program(vg_context_t *vcp, vg_ocl_context_t *vocp,
 
 	vg_ocl_hash_program(vocp, opts, buf, len, prog_hash);
 	snprintf(bin_name, sizeof(bin_name),
-		 "%02x%02x%02x%02x%02x%02x%02x%02x"
+		 "%s/%02x%02x%02x%02x%02x%02x%02x%02x"
 		 "%02x%02x%02x%02x%02x%02x%02x%02x.oclbin",
+		 P_tmpdir, 
 		 prog_hash[0], prog_hash[1], prog_hash[2], prog_hash[3],
 		 prog_hash[4], prog_hash[5], prog_hash[6], prog_hash[7],
 		 prog_hash[8], prog_hash[9], prog_hash[10], prog_hash[11],
@@ -940,7 +941,7 @@ vg_ocl_init(vg_context_t *vcp, vg_ocl_context_t *vocp, cl_device_id did,
 		end += snprintf(optbuf + end, sizeof(optbuf) - end,
 				"-cl-nv-verbose ");
 
-	if (!vg_ocl_load_program(vcp, vocp, "calc_addrs.cl", optbuf))
+	if (!vg_ocl_load_program(vcp, vocp, "/usr/lib/oclvanitygen/calc_addrs.cl", optbuf))
 		return 0;
 	return 1;
 }

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -60,6 +60,7 @@ usage(const char *name)
 "-N            Generate namecoin address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
+"-F <format>   Generate address with the given format (pubkey, compressed)\n"
 "-e            Encrypt private keys, prompt for password\n"
 "-E <password> Encrypt private keys with <password> (UNSAFE)\n"
 "-p <platform> Select OpenCL platform\n"
@@ -119,11 +120,12 @@ main(int argc, char **argv)
 	int pattfpi[MAX_FILE];
 	int npattfp = 0;
 	int pattstdin = 0;
+	int compressed = 0;
 
 	int i;
 
 	while ((opt = getopt(argc, argv,
-			     "vqik1NTX:eE:p:P:d:w:t:g:b:VSh?f:o:s:D:")) != -1) {
+			     "vqik1NTX:F:eE:p:P:d:w:t:g:b:VSh?f:o:s:D:")) != -1) {
 		switch (opt) {
 		case 'v':
 			verbose = 2;
@@ -151,6 +153,16 @@ main(int argc, char **argv)
 		case 'X':
 			addrtype = atoi(optarg);
 			privtype = 128 + addrtype;
+			break;
+		case 'F':
+			if (!strcmp(optarg, "compressed"))
+				compressed = 1;
+			else
+			if (strcmp(optarg, "pubkey")) {
+				fprintf(stderr,
+					"Invalid format '%s'\n", optarg);
+				return 1;
+			}
 			break;
 		case 'e':
 			prompt_password = 1;
@@ -330,6 +342,7 @@ main(int argc, char **argv)
 					    caseinsensitive);
 	}
 
+	vcp->vc_compressed = compressed;
 	vcp->vc_verbose = verbose;
 	vcp->vc_result_file = result_file;
 	vcp->vc_remove_on_match = remove_on_match;

--- a/paperwallet.sh
+++ b/paperwallet.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# paper wallet generator
+#
+# takes a list of addresses and privkeys (as produced by bulkwallet.sh) on 
+# stdin, produces HTML output with QR codes
+#
+# depends on base64 and qrencode
+
+cat <<EOF
+<html>
+<body>
+<h1>Paper Wallet for 
+EOF
+whoami
+cat <<EOF
+</h1><h2>Generated 
+EOF
+date
+cat <<EOF
+</h2>
+<table style="table-layout: fixed; word-wrap: break-word; width: 800px;">
+EOF
+
+sed "s/\(.*\) \(.*\)/echo -en \"<tr><td style=\\\\\"text-align: center; width: 150px;\\\\\"><img src=\\\\\"data:image\/png;base64,\"; qrencode -l L -o - \1 | base64 -w 0; echo \"\\\\\" \\\\><\/td><td style=\\\\\"width: 500px; font-family: monospace;\\\\\"><p style=\\\\\"text-align: left;\\\\\">\1<\/p><p style=\\\\\"text-align: right;\\\\\">\2<\/p><\/td><td style=\\\\\"text-align: center; width: 150px;\\\\\"><img src=\\\\\"data:image\/png;base64,\"; qrencode -l L -o - \2 | base64 -w 0; echo \"\\\\\" \\\\><\/td><\/tr>\"/" | bash
+
+cat <<EOF
+</table>
+</body>
+</html>
+EOF

--- a/pattern.c
+++ b/pattern.c
@@ -256,7 +256,7 @@ vg_exec_context_calc_address(vg_exec_context_t *vxcp)
 	}
 	len = EC_POINT_point2oct(pgroup,
 				 pubkey,
-				 POINT_CONVERSION_UNCOMPRESSED,
+				 vxcp->vxc_vc->vc_compressed ? POINT_CONVERSION_COMPRESSED : POINT_CONVERSION_UNCOMPRESSED,
 				 eckey_buf,
 				 sizeof(eckey_buf),
 				 vxcp->vxc_bnctx);

--- a/pattern.c
+++ b/pattern.c
@@ -528,9 +528,14 @@ vg_output_match_console(vg_context_t *vcp, EC_KEY *pkey, const char *pattern)
 	}
 
 	assert(EC_KEY_check_key(pkey));
-	vg_encode_address(ppnt,
-			  EC_KEY_get0_group(pkey),
-			  vcp->vc_pubkeytype, addr_buf);
+	if (vcp->vc_compressed)
+		vg_encode_address_compressed(ppnt,
+				  EC_KEY_get0_group(pkey),
+				  vcp->vc_pubkeytype, addr_buf);
+	else
+		vg_encode_address(ppnt,
+				  EC_KEY_get0_group(pkey),
+				  vcp->vc_pubkeytype, addr_buf);
 	if (isscript)
 		vg_encode_script_address(ppnt,
 					 EC_KEY_get0_group(pkey),
@@ -550,7 +555,10 @@ vg_output_match_console(vg_context_t *vcp, EC_KEY *pkey, const char *pattern)
 		}
 	}
 	if (!vcp->vc_key_protect_pass) {
-		vg_encode_privkey(pkey, vcp->vc_privtype, privkey_buf);
+		if (vcp->vc_compressed)
+			vg_encode_privkey_compressed(pkey, vcp->vc_privtype, privkey_buf);
+		else
+			vg_encode_privkey(pkey, vcp->vc_privtype, privkey_buf);
 	}
 
 	if (!vcp->vc_result_file || (vcp->vc_verbose > 0)) {

--- a/pattern.h
+++ b/pattern.h
@@ -88,6 +88,7 @@ enum vg_format {
 
 /* Application-level context, incl. parameters and global pattern store */
 struct _vg_context_s {
+        int			vc_compressed;
 	int			vc_addrtype;
 	int			vc_privtype;
 	unsigned long		vc_npatterns;

--- a/util.h
+++ b/util.h
@@ -38,10 +38,13 @@ extern int vg_b58_decode_check(const char *input, void *buf, size_t len);
 
 extern void vg_encode_address(const EC_POINT *ppoint, const EC_GROUP *pgroup,
 			      int addrtype, char *result);
+extern void vg_encode_address_compressed(const EC_POINT *ppoint, const EC_GROUP *pgroup,
+			      int addrtype, char *result);
 extern void vg_encode_script_address(const EC_POINT *ppoint,
 				     const EC_GROUP *pgroup,
 				     int addrtype, char *result);
 extern void vg_encode_privkey(const EC_KEY *pkey, int addrtype, char *result);
+extern void vg_encode_privkey_compressed(const EC_KEY *pkey, int addrtype, char *result);
 extern int vg_set_privkey(const BIGNUM *bnpriv, EC_KEY *pkey);
 extern int vg_decode_privkey(const char *b58encoded,
 			     EC_KEY *pkey, int *addrtype);

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -114,7 +114,7 @@ vg_thread_loop(void *arg)
 
 	} else {
 		eckey_buf = hash_buf;
-		hash_len = 65;
+		hash_len = (vcp->vc_compressed)?33:65;
 	}
 
 	while (!vcp->vc_halt) {
@@ -194,11 +194,11 @@ vg_thread_loop(void *arg)
 		for (i = 0; i < nbatch; i++, vxcp->vxc_delta++) {
 			/* Hash the public key */
 			len = EC_POINT_point2oct(pgroup, ppnt[i],
-						 POINT_CONVERSION_UNCOMPRESSED,
+						 (vcp->vc_compressed)?POINT_CONVERSION_COMPRESSED:POINT_CONVERSION_UNCOMPRESSED,
 						 eckey_buf,
-						 65,
+						 (vcp->vc_compressed)?33:65,
 						 vxcp->vxc_bnctx);
-			assert(len == 65);
+			assert(len == 65 || len == 33);
 
 			SHA256(hash_buf, hash_len, hash1);
 			RIPEMD160(hash1, sizeof(hash1), &vxcp->vxc_binres[1]);
@@ -311,10 +311,11 @@ usage(const char *name)
 "-i            Case-insensitive prefix search\n"
 "-k            Keep pattern and continue search after finding a match\n"
 "-1            Stop after first match\n"
+"-L            Generate litecoin address\n"
 "-N            Generate namecoin address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
-"-F <format>   Generate address with the given format (pubkey or script)\n"
+"-F <format>   Generate address with the given format (pubkey, compressed, script)\n"
 "-P <pubkey>   Specify base public key for piecewise key generation\n"
 "-e            Encrypt private keys, prompt for password\n"
 "-E <password> Encrypt private keys with <password> (UNSAFE)\n"
@@ -358,11 +359,15 @@ main(int argc, char **argv)
 	int pattfpi[MAX_FILE];
 	int npattfp = 0;
 	int pattstdin = 0;
+	int compressed = 0;
 
 	int i;
 
-	while ((opt = getopt(argc, argv, "vqnrik1eE:P:NTX:F:t:h?f:o:s:")) != -1) {
+	while ((opt = getopt(argc, argv, "Lvqnrik1eE:P:NTX:F:t:h?f:o:s:")) != -1) {
 		switch (opt) {
+		case 'c':
+		        compressed = 1;
+		        break;
 		case 'v':
 			verbose = 2;
 			break;
@@ -389,6 +394,11 @@ main(int argc, char **argv)
 			privtype = 180;
 			scriptaddrtype = -1;
 			break;
+		case 'L':
+			addrtype = 48;
+			privtype = 176;
+			scriptaddrtype = -1;
+			break;
 		case 'T':
 			addrtype = 111;
 			privtype = 239;
@@ -402,7 +412,10 @@ main(int argc, char **argv)
 		case 'F':
 			if (!strcmp(optarg, "script"))
 				format = VCF_SCRIPT;
-			else
+                        else
+                        if (!strcmp(optarg, "compressed"))
+                                compressed = 1;
+                        else
 			if (strcmp(optarg, "pubkey")) {
 				fprintf(stderr,
 					"Invalid format '%s'\n", optarg);
@@ -544,6 +557,7 @@ main(int argc, char **argv)
 					    caseinsensitive);
 	}
 
+	vcp->vc_compressed = compressed;
 	vcp->vc_verbose = verbose;
 	vcp->vc_result_file = result_file;
 	vcp->vc_remove_on_match = remove_on_match;


### PR DESCRIPTION
This contains some changes to find compressed vanity addresses.  CPU-only as I know nothing about OpenCL, but it's generated valid Bitcoin, Litecoin, and Yacoin compressed addresses.  

I've also added a flag for Litecoin addresses, so you can use -L instead of -X 48. 

(Use -X 77 to get Yacoin addresses.)
