### PR TITLE
Added -P flag to oclvanityminer usage (already supported)

### DIFF
--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -60,6 +60,7 @@ usage(const char *name)
 "-N            Generate namecoin address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
+"-P <pubkey>   Specify base public key for piecewise key generation\n"
 "-e            Encrypt private keys, prompt for password\n"
 "-E <password> Encrypt private keys with <password> (UNSAFE)\n"
 "-p <platform> Select OpenCL platform\n"


### PR DESCRIPTION
There were some minor gripes in the bitcointalk forum threads earlier on (I've just been getting into this and started address-mining on my AMD Radeon), about the -P of both ocl and plain vanitygen; the ocl program doesn't list -P in its usage though it works (or acts like it does).
