### PR TITLE
Updated vanitygen.c to support macOS CPU count

### DIFF
--- a/vanitygen.c
+++ b/vanitygen.c
@@ -244,6 +244,12 @@ out:
 int
 count_processors(void)
 {
+#if defined(__APPLE__)
+    int count;
+    size_t count_len = sizeof(count);
+    if (sysctlbyname("hw.logicalcpu", &count, &count_len, NULL, 0) != 0 || count_len != sizeof(count))
+        count = -1;
+#else
 	FILE *fp;
 	char buf[512];
 	int count = 0;
@@ -257,6 +263,7 @@ count_processors(void)
 			count += 1;
 	}
 	fclose(fp);
+#endif
 	return count;
 }
 #endif


### PR DESCRIPTION
Added an apple specific logical CPU count alternate implementation using sysctl for the count_processors function, as /proc is not available in macOS.