### PR TITLE
Use sysconf on macOS to determine number of CPUs

### DIFF
--- a/vanitygen.c
+++ b/vanitygen.c
@@ -244,6 +244,9 @@ out:
 int
 count_processors(void)
 {
+#if defined(__APPLE__)
+    int count = sysconf(_SC_NPROCESSORS_ONLN);
+#else
 	FILE *fp;
 	char buf[512];
 	int count = 0;
@@ -257,7 +260,8 @@ count_processors(void)
 			count += 1;
 	}
 	fclose(fp);
-	return count;
+#endif
+    return count;
 }
 #endif
 


### PR DESCRIPTION
Added `#if defined(__APPLE__)` wrapper for count_processors, using `sysconf` (in _libc_, include _unistd.h_ which is already indirectly included).
`sysconf(_SC_NPROCESSORS_ONLN)` returns the number of processors currently online or -1 if there was an error, this function uses -1 to denote an error so this works fine.