### PR TITLE
Detect number of processors on OSX

### DIFF
--- a/vanitygen.c
+++ b/vanitygen.c
@@ -240,7 +240,29 @@ out:
 }
 
 
-#if !defined(_WIN32)
+#if defined(__APPLE__)
+int
+count_processors(void)
+{
+       FILE *fp;
+       char buf[512];
+       int count = 0;
+
+        fp = popen("/usr/sbin/sysctl -n hw.ncpu", "r");
+        while (fgets(buf, sizeof(buf), fp) != NULL) {
+          count = atoi (buf);
+        }
+        pclose(fp);
+
+        if (!fp) {
+          return -1;
+        } else {
+          return count;
+        }
+}
+#endif
+
+#if defined(__linux__)
 int
 count_processors(void)
 {


### PR DESCRIPTION
I have not tested this on Linux, but this does the right thing on OSX.