### PR TITLE
Allow compilation with modern openssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ keyconv
 oclvanitygen
 oclvanityminer
 vanitygen
+*.sw*
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,36 +19,11 @@
 
           buildInputs = with pkgs; [ openssl pcre ];
 
-          cmakeBuildType = "Debug";
-          cmakeFlags = [
-            "-DCMAKE_BUILD_TYPE=Debug"
-
-          ];
-
-          dontStrip = true;
-
           installPhase = ''
             mkdir -p $out/bin
             cp vanitygen $out/bin
             cp keyconv $out/bin/vanitygen-keyconv
           '';
-
-          meta = with pkgs.lib; {
-            description = "Bitcoin vanity address generator";
-            longDescription = ''
-              Vanitygen can search for exact prefixes or regular expression
-              matches, so you can generate Bitcoin addresses that starts
-              with the needed mnemonic.
-              Vanitygen can generate regular bitcoin addresses, namecoin
-              addresses, and testnet addresses.
-              When searching for exact prefixes, vanitygen will ensure that
-              the prefix is possible, will provide a difficulty estimate,
-              and will run about 30% faster.
-            '';
-            homepage = "https://github.com/samr7/vanitygen";
-            # license = licenses.agpl3;
-            platforms = platforms.all;
-          };
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Bitcoin vanity address generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        packages.default = pkgs.stdenv.mkDerivation rec {
+          pname = "vanitygen";
+          version = "0.21";
+
+          src = ./.;
+
+          buildInputs = with pkgs; [ openssl pcre ];
+
+          cmakeBuildType = "Debug";
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Debug"
+
+          ];
+
+          dontStrip = true;
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp vanitygen $out/bin
+            cp keyconv $out/bin/vanitygen-keyconv
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Bitcoin vanity address generator";
+            longDescription = ''
+              Vanitygen can search for exact prefixes or regular expression
+              matches, so you can generate Bitcoin addresses that starts
+              with the needed mnemonic.
+              Vanitygen can generate regular bitcoin addresses, namecoin
+              addresses, and testnet addresses.
+              When searching for exact prefixes, vanitygen will ensure that
+              the prefix is possible, will provide a difficulty estimate,
+              and will run about 30% faster.
+            '';
+            homepage = "https://github.com/samr7/vanitygen";
+            # license = licenses.agpl3;
+            platforms = platforms.all;
+          };
+        };
+      }
+    );
+}

--- a/keyconv.c
+++ b/keyconv.c
@@ -138,7 +138,7 @@ main(int argc, char **argv)
 
 	if (key2_in) {
 		BN_CTX *bnctx;
-		BIGNUM bntmp, bntmp2;
+		BIGNUM *bntmp, *bntmp2;
 		EC_KEY *pkey2;
 
 		pkey2 = EC_KEY_new_by_curve_name(NID_secp256k1);
@@ -155,19 +155,19 @@ main(int argc, char **argv)
 			fprintf(stderr, "ERROR: Unrecognized key format\n");
 			return 1;
 		}
-		BN_init(&bntmp);
-		BN_init(&bntmp2);
+		bntmp = BN_new();
+		bntmp2 = BN_new();
 		bnctx = BN_CTX_new();
-		EC_GROUP_get_order(EC_KEY_get0_group(pkey), &bntmp2, NULL);
-		BN_mod_add(&bntmp,
+		EC_GROUP_get_order(EC_KEY_get0_group(pkey), bntmp2, NULL);
+		BN_mod_add(bntmp,
 			   EC_KEY_get0_private_key(pkey),
 			   EC_KEY_get0_private_key(pkey2),
-			   &bntmp2,
+			   bntmp2,
 			   bnctx);
-		vg_set_privkey(&bntmp, pkey);
+		vg_set_privkey(bntmp, pkey);
 		EC_KEY_free(pkey2);
-		BN_clear_free(&bntmp);
-		BN_clear_free(&bntmp2);
+		BN_clear_free(bntmp);
+		BN_clear_free(bntmp2);
 		BN_CTX_free(bnctx);
 	}
 

--- a/pattern.c
+++ b/pattern.c
@@ -151,12 +151,12 @@ vg_exec_context_init(vg_context_t *vcp, vg_exec_context_t *vxcp)
 
 	vxcp->vxc_vc = vcp;
 
-	BN_init(&vxcp->vxc_bntarg);
-	BN_init(&vxcp->vxc_bnbase);
-	BN_init(&vxcp->vxc_bntmp);
-	BN_init(&vxcp->vxc_bntmp2);
+	vxcp->vxc_bntarg = BN_new();
+	vxcp->vxc_bnbase = BN_new();
+	vxcp->vxc_bntmp = BN_new();
+	vxcp->vxc_bntmp2 = BN_new();
 
-	BN_set_word(&vxcp->vxc_bnbase, 58);
+	BN_set_word(vxcp->vxc_bnbase, 58);
 
 	vxcp->vxc_bnctx = BN_CTX_new();
 	assert(vxcp->vxc_bnctx);
@@ -196,10 +196,10 @@ vg_exec_context_del(vg_exec_context_t *vxcp)
 	if (tp->vxc_stop)
 		pthread_cond_signal(&vg_thread_upcond);
 
-	BN_clear_free(&vxcp->vxc_bntarg);
-	BN_clear_free(&vxcp->vxc_bnbase);
-	BN_clear_free(&vxcp->vxc_bntmp);
-	BN_clear_free(&vxcp->vxc_bntmp2);
+	BN_clear_free(vxcp->vxc_bntarg);
+	BN_clear_free(vxcp->vxc_bnbase);
+	BN_clear_free(vxcp->vxc_bntmp);
+	BN_clear_free(vxcp->vxc_bntmp2);
 	BN_CTX_free(vxcp->vxc_bnctx);
 	vxcp->vxc_bnctx = NULL;
 	pthread_mutex_unlock(&vg_thread_lock);
@@ -225,12 +225,12 @@ void
 vg_exec_context_consolidate_key(vg_exec_context_t *vxcp)
 {
 	if (vxcp->vxc_delta) {
-		BN_clear(&vxcp->vxc_bntmp);
-		BN_set_word(&vxcp->vxc_bntmp, vxcp->vxc_delta);
-		BN_add(&vxcp->vxc_bntmp2,
+		BN_clear(vxcp->vxc_bntmp);
+		BN_set_word(vxcp->vxc_bntmp, vxcp->vxc_delta);
+		BN_add(vxcp->vxc_bntmp2,
 		       EC_KEY_get0_private_key(vxcp->vxc_key),
-		       &vxcp->vxc_bntmp);
-		vg_set_privkey(&vxcp->vxc_bntmp2, vxcp->vxc_key);
+		       vxcp->vxc_bntmp);
+		vg_set_privkey(vxcp->vxc_bntmp2, vxcp->vxc_key);
 		vxcp->vxc_delta = 0;
 	}
 }
@@ -692,20 +692,20 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 	int b58pow, b58ceil, b58top = 0;
 	int ret = -1;
 
-	BIGNUM bntarg, bnceil, bnfloor;
-	BIGNUM bnbase;
+	BIGNUM *bntarg, *bnceil, *bnfloor;
+	BIGNUM *bnbase;
 	BIGNUM *bnap, *bnbp, *bntp;
 	BIGNUM *bnhigh = NULL, *bnlow = NULL, *bnhigh2 = NULL, *bnlow2 = NULL;
-	BIGNUM bntmp, bntmp2;
+	BIGNUM *bntmp, *bntmp2;
 
-	BN_init(&bntarg);
-	BN_init(&bnceil);
-	BN_init(&bnfloor);
-	BN_init(&bnbase);
-	BN_init(&bntmp);
-	BN_init(&bntmp2);
+	bntarg = BN_new();
+	bnceil = BN_new();
+	bnfloor = BN_new();
+	bnbase = BN_new();
+	bntmp = BN_new();
+	bntmp2 = BN_new();
 
-	BN_set_word(&bnbase, 58);
+	BN_set_word(bnbase, 58);
 
 	p = strlen(pfx);
 
@@ -732,20 +732,20 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 
 			/* First non-zero character */
 			b58top = c;
-			BN_set_word(&bntarg, c);
+			BN_set_word(bntarg, c);
 
 		} else {
-			BN_set_word(&bntmp2, c);
-			BN_mul(&bntmp, &bntarg, &bnbase, bnctx);
-			BN_add(&bntarg, &bntmp, &bntmp2);
+			BN_set_word(bntmp2, c);
+			BN_mul(bntmp, bntarg, bnbase, bnctx);
+			BN_add(bntarg, bntmp, bntmp2);
 		}
 	}
 
 	/* Power-of-two ceiling and floor values based on leading 1s */
-	BN_clear(&bntmp);
-	BN_set_bit(&bntmp, 200 - (zero_prefix * 8));
-	BN_sub(&bnceil, &bntmp, BN_value_one());
-	BN_set_bit(&bnfloor, 192 - (zero_prefix * 8));
+	BN_clear(bntmp);
+	BN_set_bit(bntmp, 200 - (zero_prefix * 8));
+	BN_sub(bnceil, bntmp, BN_value_one());
+	BN_set_bit(bnfloor, 192 - (zero_prefix * 8));
 
 	bnlow = BN_new();
 	bnhigh = BN_new();
@@ -756,13 +756,13 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 		 * numeric boundaries of the prefix.
 		 */
 
-		BN_copy(&bntmp, &bnceil);
-		bnap = &bntmp;
-		bnbp = &bntmp2;
+		BN_copy(bntmp, bnceil);
+		bnap = bntmp;
+		bnbp = bntmp2;
 		b58pow = 0;
-		while (BN_cmp(bnap, &bnbase) > 0) {
+		while (BN_cmp(bnap, bnbase) > 0) {
 			b58pow++;
-			BN_div(bnbp, NULL, bnap, &bnbase, bnctx);
+			BN_div(bnbp, NULL, bnap, bnbase, bnctx);
 			bntp = bnap;
 			bnap = bnbp;
 			bnbp = bntp;
@@ -778,11 +778,11 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 			goto out;
 		}
 
-		BN_set_word(&bntmp2, b58pow - (p - zero_prefix));
-		BN_exp(&bntmp, &bnbase, &bntmp2, bnctx);
-		BN_mul(bnlow, &bntmp, &bntarg, bnctx);
-		BN_sub(&bntmp2, &bntmp, BN_value_one());
-		BN_add(bnhigh, bnlow, &bntmp2);
+		BN_set_word(bntmp2, b58pow - (p - zero_prefix));
+		BN_exp(bntmp, bnbase, bntmp2, bnctx);
+		BN_mul(bnlow, bntmp, bntarg, bnctx);
+		BN_sub(bntmp2, bntmp, BN_value_one());
+		BN_add(bnhigh, bnlow, bntmp2);
 
 		if (b58top <= b58ceil) {
 			/* Fill out the upper range too */
@@ -790,16 +790,16 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 			bnlow2 = BN_new();
 			bnhigh2 = BN_new();
 
-			BN_mul(bnlow2, bnlow, &bnbase, bnctx);
-			BN_mul(&bntmp2, bnhigh, &bnbase, bnctx);
-			BN_set_word(&bntmp, 57);
-			BN_add(bnhigh2, &bntmp2, &bntmp);
+			BN_mul(bnlow2, bnlow, bnbase, bnctx);
+			BN_mul(bntmp2, bnhigh, bnbase, bnctx);
+			BN_set_word(bntmp, 57);
+			BN_add(bnhigh2, bntmp2, bntmp);
 
 			/*
 			 * Addresses above the ceiling will have one
 			 * fewer "1" prefix in front than we require.
 			 */
-			if (BN_cmp(&bnceil, bnlow2) < 0) {
+			if (BN_cmp(bnceil, bnlow2) < 0) {
 				/* High prefix is above the ceiling */
 				check_upper = 0;
 				BN_free(bnhigh2);
@@ -807,15 +807,15 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 				BN_free(bnlow2);
 				bnlow2 = NULL;
 			}
-			else if (BN_cmp(&bnceil, bnhigh2) < 0)
+			else if (BN_cmp(bnceil, bnhigh2) < 0)
 				/* High prefix is partly above the ceiling */
-				BN_copy(bnhigh2, &bnceil);
+				BN_copy(bnhigh2, bnceil);
 
 			/*
 			 * Addresses below the floor will have another
 			 * "1" prefix in front instead of our target.
 			 */
-			if (BN_cmp(&bnfloor, bnhigh) >= 0) {
+			if (BN_cmp(bnfloor, bnhigh) >= 0) {
 				/* Low prefix is completely below the floor */
 				assert(check_upper);
 				check_upper = 0;
@@ -826,35 +826,35 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 				bnlow = bnlow2;
 				bnlow2 = NULL;
 			}			
-			else if (BN_cmp(&bnfloor, bnlow) > 0) {
+			else if (BN_cmp(bnfloor, bnlow) > 0) {
 				/* Low prefix is partly below the floor */
-				BN_copy(bnlow, &bnfloor);
+				BN_copy(bnlow, bnfloor);
 			}
 		}
 
 	} else {
-		BN_copy(bnhigh, &bnceil);
+		BN_copy(bnhigh, bnceil);
 		BN_clear(bnlow);
 	}
 
 	/* Limit the prefix to the address type */
-	BN_clear(&bntmp);
-	BN_set_word(&bntmp, addrtype);
-	BN_lshift(&bntmp2, &bntmp, 192);
+	BN_clear(bntmp);
+	BN_set_word(bntmp, addrtype);
+	BN_lshift(bntmp2, bntmp, 192);
 
 	if (check_upper) {
-		if (BN_cmp(&bntmp2, bnhigh2) > 0) {
+		if (BN_cmp(bntmp2, bnhigh2) > 0) {
 			check_upper = 0;
 			BN_free(bnhigh2);
 			bnhigh2 = NULL;
 			BN_free(bnlow2);
 			bnlow2 = NULL;
 		}
-		else if (BN_cmp(&bntmp2, bnlow2) > 0)
-			BN_copy(bnlow2, &bntmp2);
+		else if (BN_cmp(bntmp2, bnlow2) > 0)
+			BN_copy(bnlow2, bntmp2);
 	}
 
-	if (BN_cmp(&bntmp2, bnhigh) > 0) {
+	if (BN_cmp(bntmp2, bnhigh) > 0) {
 		if (!check_upper)
 			goto not_possible;
 		check_upper = 0;
@@ -865,26 +865,26 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 		bnlow = bnlow2;
 		bnlow2 = NULL;
 	}
-	else if (BN_cmp(&bntmp2, bnlow) > 0) {
-		BN_copy(bnlow, &bntmp2);
+	else if (BN_cmp(bntmp2, bnlow) > 0) {
+		BN_copy(bnlow, bntmp2);
 	}
 
-	BN_set_word(&bntmp, addrtype + 1);
-	BN_lshift(&bntmp2, &bntmp, 192);
+	BN_set_word(bntmp, addrtype + 1);
+	BN_lshift(bntmp2, bntmp, 192);
 
 	if (check_upper) {
-		if (BN_cmp(&bntmp2, bnlow2) < 0) {
+		if (BN_cmp(bntmp2, bnlow2) < 0) {
 			check_upper = 0;
 			BN_free(bnhigh2);
 			bnhigh2 = NULL;
 			BN_free(bnlow2);
 			bnlow2 = NULL;
 		}
-		else if (BN_cmp(&bntmp2, bnhigh2) < 0)
-			BN_copy(bnlow2, &bntmp2);
+		else if (BN_cmp(bntmp2, bnhigh2) < 0)
+			BN_copy(bnlow2, bntmp2);
 	}
 
-	if (BN_cmp(&bntmp2, bnlow) < 0) {
+	if (BN_cmp(bntmp2, bnlow) < 0) {
 		if (!check_upper)
 			goto not_possible;
 		check_upper = 0;
@@ -895,8 +895,8 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 		bnlow = bnlow2;
 		bnlow2 = NULL;
 	}
-	else if (BN_cmp(&bntmp2, bnhigh) < 0) {
-		BN_copy(bnhigh, &bntmp2);
+	else if (BN_cmp(bntmp2, bnhigh) < 0) {
+		BN_copy(bnhigh, bntmp2);
 	}
 
 	/* Address ranges are complete */
@@ -917,12 +917,12 @@ get_prefix_ranges(int addrtype, const char *pfx, BIGNUM **result,
 	}
 
 out:
-	BN_clear_free(&bntarg);
-	BN_clear_free(&bnceil);
-	BN_clear_free(&bnfloor);
-	BN_clear_free(&bnbase);
-	BN_clear_free(&bntmp);
-	BN_clear_free(&bntmp2);
+	BN_clear_free(bntarg);
+	BN_clear_free(bnceil);
+	BN_clear_free(bnfloor);
+	BN_clear_free(bnbase);
+	BN_clear_free(bntmp);
+	BN_clear_free(bntmp2);
 	if (bnhigh)
 		BN_free(bnhigh);
 	if (bnlow)
@@ -1206,7 +1206,7 @@ prefix_case_iter_next(prefix_case_iter_t *cip)
 typedef struct _vg_prefix_context_s {
 	vg_context_t		base;
 	avl_root_t		vcp_avlroot;
-	BIGNUM			vcp_difficulty;
+	BIGNUM			*vcp_difficulty;
 	int			vcp_caseinsensitive;
 } vg_prefix_context_t;
 
@@ -1234,7 +1234,7 @@ vg_prefix_context_clear_all_patterns(vg_context_t *vcp)
 	vcpp->base.vc_npatterns = 0;
 	vcpp->base.vc_npatterns_start = 0;
 	vcpp->base.vc_found = 0;
-	BN_clear(&vcpp->vcp_difficulty);
+	BN_clear(vcpp->vcp_difficulty);
 }
 
 static void
@@ -1242,7 +1242,7 @@ vg_prefix_context_free(vg_context_t *vcp)
 {
 	vg_prefix_context_t *vcpp = (vg_prefix_context_t *) vcp;
 	vg_prefix_context_clear_all_patterns(vcp);
-	BN_clear_free(&vcpp->vcp_difficulty);
+	BN_clear_free(vcpp->vcp_difficulty);
 	free(vcpp);
 }
 
@@ -1254,7 +1254,7 @@ vg_prefix_context_next_difficulty(vg_prefix_context_t *vcpp,
 
 	BN_clear(bntmp);
 	BN_set_bit(bntmp, 192);
-	BN_div(bntmp2, NULL, bntmp, &vcpp->vcp_difficulty, bnctx);
+	BN_div(bntmp2, NULL, bntmp, vcpp->vcp_difficulty, bnctx);
 
 	dbuf = BN_bn2dec(bntmp2);
 	if (vcpp->base.vc_verbose > 0) {
@@ -1277,7 +1277,7 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 	prefix_case_iter_t caseiter;
 	vg_prefix_t *vp, *vp2;
 	BN_CTX *bnctx;
-	BIGNUM bntmp, bntmp2, bntmp3;
+	BIGNUM *bntmp, *bntmp2, *bntmp3;
 	BIGNUM *ranges[4];
 	int ret = 0;
 	int i, impossible = 0;
@@ -1286,9 +1286,9 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 	char *dbuf;
 
 	bnctx = BN_CTX_new();
-	BN_init(&bntmp);
-	BN_init(&bntmp2);
-	BN_init(&bntmp3);
+	bntmp = BN_new();
+	bntmp2 = BN_new();
+	bntmp3 = BN_new();
 
 	npfx = 0;
 	for (i = 0; i < npatterns; i++) {
@@ -1366,16 +1366,16 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 		npfx++;
 
 		/* Determine the probability of finding a match */
-		vg_prefix_range_sum(vp, &bntmp, &bntmp2);
-		BN_add(&bntmp2, &vcpp->vcp_difficulty, &bntmp);
-		BN_copy(&vcpp->vcp_difficulty, &bntmp2);
+		vg_prefix_range_sum(vp, bntmp, bntmp2);
+		BN_add(bntmp2, vcpp->vcp_difficulty, bntmp);
+		BN_copy(vcpp->vcp_difficulty, bntmp2);
 
 		if (vcp->vc_verbose > 1) {
-			BN_clear(&bntmp2);
-			BN_set_bit(&bntmp2, 192);
-			BN_div(&bntmp3, NULL, &bntmp2, &bntmp, bnctx);
+			BN_clear(bntmp2);
+			BN_set_bit(bntmp2, 192);
+			BN_div(bntmp3, NULL, bntmp2, bntmp, bnctx);
 
-			dbuf = BN_bn2dec(&bntmp3);
+			dbuf = BN_bn2dec(bntmp3);
 			fprintf(stderr,
 				"Prefix difficulty: %20s %s\n",
 				dbuf, patterns[i]);
@@ -1409,13 +1409,13 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 	}
 
 	if (npfx)
-		vg_prefix_context_next_difficulty(vcpp, &bntmp, &bntmp2, bnctx);
+		vg_prefix_context_next_difficulty(vcpp, bntmp, bntmp2, bnctx);
 
 	ret = (npfx != 0);
 
-	BN_clear_free(&bntmp);
-	BN_clear_free(&bntmp2);
-	BN_clear_free(&bntmp3);
+	BN_clear_free(bntmp);
+	BN_clear_free(bntmp2);
+	BN_clear_free(bntmp3);
 	BN_CTX_free(bnctx);
 	return ret;
 }
@@ -1424,39 +1424,39 @@ double
 vg_prefix_get_difficulty(int addrtype, const char *pattern)
 {
 	BN_CTX *bnctx;
-	BIGNUM result, bntmp;
+	BIGNUM *result, *bntmp;
 	BIGNUM *ranges[4];
 	char *dbuf;
 	int ret;
 	double diffret = 0.0;
 
 	bnctx = BN_CTX_new();
-	BN_init(&result);
-	BN_init(&bntmp);
+	result = BN_new();
+	bntmp = BN_new();
 
 	ret = get_prefix_ranges(addrtype,
 				pattern, ranges, bnctx);
 
 	if (ret == 0) {
-		BN_sub(&bntmp, ranges[1], ranges[0]);
-		BN_add(&result, &result, &bntmp);
+		BN_sub(bntmp, ranges[1], ranges[0]);
+		BN_add(result, result, bntmp);
 		if (ranges[2]) {
-			BN_sub(&bntmp, ranges[3], ranges[2]);
-			BN_add(&result, &result, &bntmp);
+			BN_sub(bntmp, ranges[3], ranges[2]);
+			BN_add(result, result, bntmp);
 		}
 		free_ranges(ranges);
 
-		BN_clear(&bntmp);
-		BN_set_bit(&bntmp, 192);
-		BN_div(&result, NULL, &bntmp, &result, bnctx);
+		BN_clear(bntmp);
+		BN_set_bit(bntmp, 192);
+		BN_div(result, NULL, bntmp, result, bnctx);
 
-		dbuf = BN_bn2dec(&result);
+		dbuf = BN_bn2dec(result);
 		diffret = strtod(dbuf, NULL);
 		OPENSSL_free(dbuf);
 	}
 
-	BN_clear_free(&result);
-	BN_clear_free(&bntmp);
+	BN_clear_free(result);
+	BN_clear_free(bntmp);
 	BN_CTX_free(bnctx);
 	return diffret;
 }
@@ -1475,10 +1475,10 @@ vg_prefix_test(vg_exec_context_t *vxcp)
 	 * check code.
 	 */
 
-	BN_bin2bn(vxcp->vxc_binres, 25, &vxcp->vxc_bntarg);
+	BN_bin2bn(vxcp->vxc_binres, 25, vxcp->vxc_bntarg);
 
 research:
-	vp = vg_prefix_avl_search(&vcpp->vcp_avlroot, &vxcp->vxc_bntarg);
+	vp = vg_prefix_avl_search(&vcpp->vcp_avlroot, vxcp->vxc_bntarg);
 	if (vp) {
 		if (vg_exec_context_upgrade_lock(vxcp))
 			goto research;
@@ -1496,20 +1496,20 @@ research:
 		if (vcpp->base.vc_remove_on_match) {
 			/* Subtract the range from the difficulty */
 			vg_prefix_range_sum(vp,
-					    &vxcp->vxc_bntarg,
-					    &vxcp->vxc_bntmp);
-			BN_sub(&vxcp->vxc_bntmp,
-			       &vcpp->vcp_difficulty,
-			       &vxcp->vxc_bntarg);
-			BN_copy(&vcpp->vcp_difficulty, &vxcp->vxc_bntmp);
+					    vxcp->vxc_bntarg,
+					    vxcp->vxc_bntmp);
+			BN_sub(vxcp->vxc_bntmp,
+			       vcpp->vcp_difficulty,
+			       vxcp->vxc_bntarg);
+			BN_copy(vcpp->vcp_difficulty, vxcp->vxc_bntmp);
 
 			vg_prefix_delete(&vcpp->vcp_avlroot,vp);
 			vcpp->base.vc_npatterns--;
 
 			if (!avl_root_empty(&vcpp->vcp_avlroot))
 				vg_prefix_context_next_difficulty(
-					vcpp, &vxcp->vxc_bntmp,
-					&vxcp->vxc_bntmp2,
+					vcpp, vxcp->vxc_bntmp,
+					vxcp->vxc_bntmp2,
 					vxcp->vxc_bnctx);
 			vcpp->base.vc_pattern_generation++;
 		}
@@ -1590,7 +1590,7 @@ vg_prefix_context_new(int addrtype, int privtype, int caseinsensitive)
 		vcpp->base.vc_test = vg_prefix_test;
 		vcpp->base.vc_hash160_sort = vg_prefix_hash160_sort;
 		avl_root_init(&vcpp->vcp_avlroot);
-		BN_init(&vcpp->vcp_difficulty);
+		vcpp->vcp_difficulty = BN_new();
 		vcpp->vcp_caseinsensitive = caseinsensitive;
 	}
 	return &vcpp->base;
@@ -1716,21 +1716,21 @@ vg_regex_test(vg_exec_context_t *vxcp)
 	unsigned char hash1[32], hash2[32];
 	int i, zpfx, p, d, nres, re_vec[9];
 	char b58[40];
-	BIGNUM bnrem;
+	BIGNUM *bnrem;
 	BIGNUM *bn, *bndiv, *bnptmp;
 	int res = 0;
 
 	pcre *re;
 
-	BN_init(&bnrem);
+	bnrem = BN_new();
 
 	/* Hash the hash and write the four byte check code */
 	SHA256(vxcp->vxc_binres, 21, hash1);
 	SHA256(hash1, sizeof(hash1), hash2);
 	memcpy(&vxcp->vxc_binres[21], hash2, 4);
 
-	bn = &vxcp->vxc_bntmp;
-	bndiv = &vxcp->vxc_bntmp2;
+	bn = vxcp->vxc_bntmp;
+	bndiv = vxcp->vxc_bntmp2;
 
 	BN_bin2bn(vxcp->vxc_binres, 25, bn);
 
@@ -1739,11 +1739,11 @@ vg_regex_test(vg_exec_context_t *vxcp)
 	p = sizeof(b58) - 1;
 	b58[p] = '\0';
 	while (!BN_is_zero(bn)) {
-		BN_div(bndiv, &bnrem, bn, &vxcp->vxc_bnbase, vxcp->vxc_bnctx);
+		BN_div(bndiv, bnrem, bn, vxcp->vxc_bnbase, vxcp->vxc_bnctx);
 		bnptmp = bn;
 		bn = bndiv;
 		bndiv = bnptmp;
-		d = BN_get_word(&bnrem);
+		d = BN_get_word(bnrem);
 		b58[--p] = vg_b58_alphabet[d];
 	}
 	while (zpfx--) {
@@ -1813,7 +1813,7 @@ restart_loop:
 		res = 1;
 	}
 out:
-	BN_clear_free(&bnrem);
+	BN_clear_free(bnrem);
 	return res;
 }
 

--- a/pattern.h
+++ b/pattern.h
@@ -51,10 +51,10 @@ struct _vg_exec_context_s {
 	EC_KEY				*vxc_key;
 	int				vxc_delta;
 	unsigned char			vxc_binres[28];
-	BIGNUM				vxc_bntarg;
-	BIGNUM				vxc_bnbase;
-	BIGNUM				vxc_bntmp;
-	BIGNUM				vxc_bntmp2;
+	BIGNUM				*vxc_bntarg;
+	BIGNUM				*vxc_bnbase;
+	BIGNUM				*vxc_bntmp;
+	BIGNUM				*vxc_bntmp2;
 
 	vg_exec_context_threadfunc_t	vxc_threadfunc;
 	pthread_t			vxc_pthread;

--- a/util.c
+++ b/util.c
@@ -105,19 +105,19 @@ vg_b58_encode_check(void *buf, size_t len, char *result)
 
 	BN_CTX *bnctx;
 	BIGNUM *bn, *bndiv, *bntmp;
-	BIGNUM bna, bnb, bnbase, bnrem;
+	BIGNUM *bna, *bnb, *bnbase, *bnrem;
 	unsigned char *binres;
 	int brlen, zpfx;
 
 	bnctx = BN_CTX_new();
-	BN_init(&bna);
-	BN_init(&bnb);
-	BN_init(&bnbase);
-	BN_init(&bnrem);
-	BN_set_word(&bnbase, 58);
+	(bna) = BN_new();
+	(bnb) = BN_new();
+	(bnbase) = BN_new();
+	(bnrem) = BN_new();
+	BN_set_word(bnbase, 58);
 
-	bn = &bna;
-	bndiv = &bnb;
+	bn = bna;
+	bndiv = bnb;
 
 	brlen = (2 * len) + 4;
 	binres = (unsigned char*) malloc(brlen);
@@ -133,11 +133,11 @@ vg_b58_encode_check(void *buf, size_t len, char *result)
 
 	p = brlen;
 	while (!BN_is_zero(bn)) {
-		BN_div(bndiv, &bnrem, bn, &bnbase, bnctx);
+		BN_div(bndiv, bnrem, bn, bnbase, bnctx);
 		bntmp = bn;
 		bn = bndiv;
 		bndiv = bntmp;
-		d = BN_get_word(&bnrem);
+		d = BN_get_word(bnrem);
 		binres[--p] = vg_b58_alphabet[d];
 	}
 
@@ -149,10 +149,10 @@ vg_b58_encode_check(void *buf, size_t len, char *result)
 	result[brlen - p] = '\0';
 
 	free(binres);
-	BN_clear_free(&bna);
-	BN_clear_free(&bnb);
-	BN_clear_free(&bnbase);
-	BN_clear_free(&bnrem);
+	BN_clear_free(bna);
+	BN_clear_free(bnb);
+	BN_clear_free(bnbase);
+	BN_clear_free(bnrem);
 	BN_CTX_free(bnctx);
 }
 
@@ -164,16 +164,16 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 {
 	int i, l, c;
 	unsigned char *xbuf = NULL;
-	BIGNUM bn, bnw, bnbase;
+	BIGNUM *bn, *bnw, *bnbase;
 	BN_CTX *bnctx;
 	unsigned char hash1[32], hash2[32];
 	int zpfx;
 	int res = 0;
 
-	BN_init(&bn);
-	BN_init(&bnw);
-	BN_init(&bnbase);
-	BN_set_word(&bnbase, 58);
+	bn = BN_new();
+	bnw = BN_new();
+	bnbase = BN_new();
+	BN_set_word(bnbase, 58);
 	bnctx = BN_CTX_new();
 
 	/* Build a bignum from the encoded value */
@@ -184,10 +184,10 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 		c = vg_b58_reverse_map[(int)input[i]];
 		if (c < 0)
 			goto out;
-		BN_clear(&bnw);
-		BN_set_word(&bnw, c);
-		BN_mul(&bn, &bn, &bnbase, bnctx);
-		BN_add(&bn, &bn, &bnw);
+		BN_clear(bnw);
+		BN_set_word(bnw, c);
+		BN_mul(bn, bn, bnbase, bnctx);
+		BN_add(bn, bn, bnw);
 	}
 
 	/* Copy the bignum to a byte buffer */
@@ -198,7 +198,7 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 			break;
 		zpfx++;
 	}
-	c = BN_num_bytes(&bn);
+	c = BN_num_bytes(bn);
 	l = zpfx + c;
 	if (l < 5)
 		goto out;
@@ -208,7 +208,7 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 	if (zpfx)
 		memset(xbuf, 0, zpfx);
 	if (c)
-		BN_bn2bin(&bn, xbuf + zpfx);
+		BN_bn2bin(bn, xbuf + zpfx);
 
 	/* Check the hash code */
 	l -= 4;
@@ -228,9 +228,9 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 out:
 	if (xbuf)
 		free(xbuf);
-	BN_clear_free(&bn);
-	BN_clear_free(&bnw);
-	BN_clear_free(&bnbase);
+	BN_clear_free(bn);
+	BN_clear_free(bnw);
+	BN_clear_free(bnbase);
 	BN_CTX_free(bnctx);
 	return res;
 }
@@ -334,7 +334,7 @@ vg_set_privkey(const BIGNUM *bnpriv, EC_KEY *pkey)
 int
 vg_decode_privkey(const char *b58encoded, EC_KEY *pkey, int *addrtype)
 {
-	BIGNUM bnpriv;
+	BIGNUM *bnpriv;
 	unsigned char ecpriv[48];
 	int res;
 
@@ -342,10 +342,10 @@ vg_decode_privkey(const char *b58encoded, EC_KEY *pkey, int *addrtype)
 	if (res != 33)
 		return 0;
 
-	BN_init(&bnpriv);
-	BN_bin2bn(ecpriv + 1, res - 1, &bnpriv);
-	res = vg_set_privkey(&bnpriv, pkey);
-	BN_clear_free(&bnpriv);
+	bnpriv = BN_new();
+	BN_bin2bn(ecpriv + 1, res - 1, bnpriv);
+	res = vg_set_privkey(bnpriv, pkey);
+	BN_clear_free(bnpriv);
 	*addrtype = ecpriv[0];
 	return 1;
 }
@@ -539,20 +539,21 @@ vg_protect_crypt(int parameter_group,
 	pbkdf_digest = params->pbkdf_hash_getter();
 	cipher = params->cipher_getter();
 
+	int block_size = EVP_CIPHER_block_size(cipher);
 	if (params->mode == 0) {
 		/* Brief encoding */
 		salt_len = 4;
 		hmac_len = 8;
 		hmac_keylen = 16;
-		ciphertext_len = ((plaintext_len + cipher->block_size - 1) /
-				  cipher->block_size) * cipher->block_size;
+		ciphertext_len = ((plaintext_len + block_size - 1) /
+				  block_size) * block_size;
 		pkcs7_padding = 0;
 		hmac_digest = EVP_sha256();
 	} else {
 		/* PKCS-compliant encoding */
 		salt_len = 8;
-		ciphertext_len = ((plaintext_len + cipher->block_size) /
-				  cipher->block_size) * cipher->block_size;
+		ciphertext_len = ((plaintext_len + block_size) /
+				  block_size) * block_size;
 		hmac_digest = NULL;
 	}
 
@@ -573,17 +574,18 @@ vg_protect_crypt(int parameter_group,
 	} else {
 		salt = NULL;
 	}
-
+	int key_len = EVP_CIPHER_key_length(cipher);
+	int iv_len = EVP_CIPHER_iv_length(cipher);
 	PKCS5_PBKDF2_HMAC((const char *) pass, strlen(pass) + 1,
 			  salt, salt_len,
 			  params->iterations,
 			  pbkdf_digest,
-			  cipher->key_len + cipher->iv_len + hmac_keylen,
+			  key_len + iv_len + hmac_keylen,
 			  keymaterial);
 
 	if (!EVP_CipherInit(ctx, cipher,
 			    keymaterial,
-			    keymaterial + cipher->key_len,
+			    keymaterial + key_len,
 			    enc)) {
 		fprintf(stderr, "ERROR: could not configure cipher\n");
 		goto out;
@@ -619,7 +621,7 @@ vg_protect_crypt(int parameter_group,
 	if (hmac_len) {
 		hlen = sizeof(hmac);
 		HMAC(hmac_digest,
-		     keymaterial + cipher->key_len + cipher->iv_len,
+		     keymaterial + key_len + iv_len,
 		     hmac_keylen,
 		     enc ? data_in : data_out, plaintext_len,
 		     hmac, &hlen);
@@ -698,7 +700,7 @@ vg_protect_decode_privkey(EC_KEY *pkey, int *keytype,
 {
 	unsigned char ecpriv[64];
 	unsigned char ecenc[128];
-	BIGNUM bn;
+	BIGNUM *bn;
 	int restype;
 	int res;
 
@@ -722,10 +724,10 @@ vg_protect_decode_privkey(EC_KEY *pkey, int *keytype,
 
 	res = 1;
 	if (pkey) {
-		BN_init(&bn);
-		BN_bin2bn(ecpriv, 32, &bn);
-		res = vg_set_privkey(&bn, pkey);
-		BN_clear_free(&bn);
+		bn = BN_new();
+		BN_bin2bn(ecpriv, 32, bn);
+		res = vg_set_privkey(bn, pkey);
+		BN_clear_free(bn);
 		OPENSSL_cleanse(ecpriv, sizeof(ecpriv));
 	}
 

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -32,6 +32,7 @@
 #include "pattern.h"
 #include "util.h"
 
+#define BN_MASK2        (0xffffffffffffffffL)
 const char *version = VANITYGEN_VERSION;
 
 
@@ -89,8 +90,8 @@ vg_thread_loop(void *arg)
 		exit(1);
 	}
 
-	BN_set_word(&vxcp->vxc_bntmp, ptarraysize);
-	EC_POINT_mul(pgroup, pbatchinc, &vxcp->vxc_bntmp, NULL, NULL,
+	BN_set_word(vxcp->vxc_bntmp, ptarraysize);
+	EC_POINT_mul(pgroup, pbatchinc, vxcp->vxc_bntmp, NULL, NULL,
 		     vxcp->vxc_bnctx);
 	EC_POINT_make_affine(pgroup, pbatchinc, vxcp->vxc_bnctx);
 
@@ -125,12 +126,12 @@ vg_thread_loop(void *arg)
 			npoints = 0;
 
 			/* Determine rekey interval */
-			EC_GROUP_get_order(pgroup, &vxcp->vxc_bntmp,
+			EC_GROUP_get_order(pgroup, vxcp->vxc_bntmp,
 					   vxcp->vxc_bnctx);
-			BN_sub(&vxcp->vxc_bntmp2,
-			       &vxcp->vxc_bntmp,
+			BN_sub(vxcp->vxc_bntmp2,
+			       vxcp->vxc_bntmp,
 			       EC_KEY_get0_private_key(pkey));
-			rekey_at = BN_get_word(&vxcp->vxc_bntmp2);
+			rekey_at = BN_get_word(vxcp->vxc_bntmp2);
 			if ((rekey_at == BN_MASK2) || (rekey_at > rekey_max))
 				rekey_at = rekey_max;
 			assert(rekey_at > 0);


### PR DESCRIPTION
Minor fixed to enable compilation using openssl3

This isn't a full fix - it still uses deprecated functions, but the core functionality works.

Does not cover ocl.